### PR TITLE
Define units for pressure bin in binRBR

### DIFF
--- a/binRBR.m
+++ b/binRBR.m
@@ -45,6 +45,7 @@ switch by
   case 'pressure'
     binCenter = [binWidth:binWidth:ceil(max(in.Pressure))]';
     out.Pressure = binCenter;
+    unit = 'dbar'; % for processing log text
   case 'depth'
     in.Depth = -gsw_z_from_p(in.Pressure,52);
     binCenter = [binWidth:binWidth:ceil(max(in.Depth))]';


### PR DESCRIPTION
Units for pressure binning were previously undefined. The units variable has been defined to suppress the error that arised when printing the log message.