### PR TITLE
Fix error thrown by gsw_p_from_z.m in TEOS-10 toolkit

### DIFF
--- a/binRBR.m
+++ b/binRBR.m
@@ -37,6 +37,8 @@ vars = vars(ind);
 vars = vars(~strcmp(vars,{'Pressure'}));
 vars = vars(~strcmp(vars,{'Depth'}));
 
+% cast binWidth to double incase it is passed in as an integer
+binWidth = double(binWidth)
 
 
 out = in;

--- a/binRBR.m
+++ b/binRBR.m
@@ -51,7 +51,7 @@ switch by
   case 'depth'
     in.Depth = -gsw_z_from_p(in.Pressure,52);
     binCenter = [binWidth:binWidth:ceil(max(in.Depth))]';
-    out.Depth = double(binCenter);
+    out.Depth = binCenter;
     out.Pressure = gsw_p_from_z(-out.Depth,52);
     unit = 'm'; % for processing log text
 end

--- a/binRBR.m
+++ b/binRBR.m
@@ -44,11 +44,11 @@ out = in;
 switch by
   case 'pressure'
     binCenter = [binWidth:binWidth:ceil(max(in.Pressure))]';
-    out.Pressure = binCenter;
+    out.Pressure = double(binCenter);
   case 'depth'
     in.Depth = -gsw_z_from_p(in.Pressure,52);
     binCenter = [binWidth:binWidth:ceil(max(in.Depth))]';
-    out.Depth = binCenter;
+    out.Depth = double(binCenter);
     out.Pressure = gsw_p_from_z(-out.Depth,52);
     unit = 'm'; % for processing log text
 end

--- a/binRBR.m
+++ b/binRBR.m
@@ -4,10 +4,10 @@ function out = binRBR(in,by,binWidth)
 %
 %  out = binRBR(in,by,binWidth);
 %
-%   where 
-%     in        : structure of RBR profiler data (i.e., created 
+%   where
+%     in        : structure of RBR profiler data (i.e., created
 %                 by output from rbrExtractVals.m)
-%     by        : is a string specifying how to bin the  data 
+%     by        : is a string specifying how to bin the  data
 %                 ('depth' or 'pressure')
 %     binWidth  : is the bin width
 %
@@ -15,13 +15,13 @@ function out = binRBR(in,by,binWidth)
 %         depth is calculated from pressure and latitude using the GSW
 %         function gsw_z_from_p
 
- 
+
 %% for testing
-% in = profile; 
+% in = profile;
 % % by = 'depth';
 % by = 'pressure';
 % binWidth = 1;
-  
+
 
 %% develop a list of sensors to bin
 vars = fieldnames(in);
@@ -56,7 +56,7 @@ out.units(end+1) = {'m'};
 
 
 
-%  initialize the binned output fields    
+%  initialize the binned output fields
 for k=1:length(vars),
   out.(vars{k}) = NaN(length(binCenter),1);
 end
@@ -72,10 +72,10 @@ for k=1:length(binCenter),
       kk = in.Depth>=binCenter(k)-binWidth/2 & ...
            in.Depth< binCenter(k)+binWidth/2;
   end
-  
+
   if any(kk),
      for j=1:length(vars),
-       out.(vars{j})(k) = nanmean(in.(vars{j})(kk));         
+       out.(vars{j})(k) = nanmean(in.(vars{j})(kk));
      end
   end
 

--- a/binRBR.m
+++ b/binRBR.m
@@ -44,7 +44,7 @@ out = in;
 switch by
   case 'pressure'
     binCenter = [binWidth:binWidth:ceil(max(in.Pressure))]';
-    out.Pressure = double(binCenter);
+    out.Pressure = binCenter;
   case 'depth'
     in.Depth = -gsw_z_from_p(in.Pressure,52);
     binCenter = [binWidth:binWidth:ceil(max(in.Depth))]';


### PR DESCRIPTION
gsw_p_from_z is throwing `Integers can only be combined with integers of the same class, or scalar doubles` when passing the input depth or pressure vector created in binRBR.m. The binRBR.m function creates int64 vectors by default. This pull request resolves the gsw error by explicitly casting the binned int64 pressure and depths vectors to type double.